### PR TITLE
Adds screen config

### DIFF
--- a/.screenrc
+++ b/.screenrc
@@ -1,0 +1,6 @@
+sessionname "reason-tools build console"
+defscrollback 10000
+screen -t "bsb -- `C-a \` to quit" 0 npm run start
+split
+focus down
+screen -t "webpack -- `C-a \` to quit - `C-a Esc` to scroll" 1 npm run watch:js

--- a/package.json
+++ b/package.json
@@ -39,7 +39,8 @@
     "editor": "eval $(dependencyEnv) && eval $EDITOR",
     "whereisocamlmerlin": "eval $(dependencyEnv) && which ocamlmerlin-reason",
     "watch": "eval $(dependencyEnv) && nopam && ./node_modules/rebel/_build/src/rebel -P",
-    "watch:js": "webpack -w"
+    "watch:js": "webpack -w",
+    "watch:screen": "screen -c .screenrc"
   },
   "dependencies": {
     "@opam-alpha/merlin": "^ 2.5.0",


### PR DESCRIPTION
`screen` is like `tmux`, but easier to set up. This adds a screen config and a script to run both bsb and webpack simultanesously in a single terminal window. Much quality of life improvement :)