### PR TITLE
Remove toplevel prompt before refmt

### DIFF
--- a/src/extension/Content.re
+++ b/src/extension/Content.re
@@ -1,5 +1,4 @@
 open LocalDom;
-open Common;
 
 Hljs.registerLanguage "ocaml" [%bs.raw "require('highlight.js/lib/languages/ocaml')"];
 Hljs.configure {"classPrefix": "", "languages": [|"ocaml"|]};
@@ -15,7 +14,7 @@ Protocol.ToggleConversion.listen ConvertPage.toggle;
 Protocol.RefmtSelection.listen (
   fun () => {
     let selection = Window.getSelection ();
-    let text = selection |> Selection.toString |> normalizeText;
+    let text = selection |> Selection.toString;
     Selection.removeAllRanges selection;
     Overlay.try_ text
   }

--- a/src/extension/common/Protocol.re
+++ b/src/extension/common/Protocol.re
@@ -1,4 +1,5 @@
 open Rebase;
+open Common;
 
 module Refmt = {
   exception DeserializationFail;
@@ -27,7 +28,8 @@ module Refmt = {
   | _ => raise DeserializationFail;
 
   let send : string => (response => unit) => unit =
-    fun text cb => Message.query "refmt:refmt" { input: text } (fun response => cb (deserialize response));
+    fun text cb =>
+      Message.query "refmt:refmt" { input: text |> normalizeText |> untoplevel } (fun response => cb (deserialize response));
 
   let listen : (request => (response => unit) => unit) => unit =
     fun cb => Message.receive "refmt:refmt" (fun request _ respond => cb request (fun r => r |> serialize |> respond));

--- a/src/extension/content/Common.re
+++ b/src/extension/content/Common.re
@@ -4,6 +4,16 @@ let normalizeText text =>
   text |> Js.String.trim |> Js.String.replaceByRe [%bs.re {|/[^\x00-\x7F]/g|}] " " |>
   Js.String.replace (Js.String.fromCharCode 65533) "";
 
+let untoplevel text => {
+  open Js.String;
+
+  if (text |> startsWith "# ") {
+    text |> sliceToEnd from::2;
+  } else {
+    text;
+  }
+};
+
 let getElementsByTagName maybeEl name =>
   (
     switch maybeEl {

--- a/src/extension/content/ConvertPage.re
+++ b/src/extension/content/ConvertPage.re
@@ -28,7 +28,7 @@ let doListing mode state listing => {
   open Retrieve;
   let {els, text, replace} = listing;
   Protocol.Refmt.send
-    (normalizeText text)
+    text
     (
       fun response => {
         switch response {

--- a/src/extension/content/Overlay.re
+++ b/src/extension/content/Overlay.re
@@ -27,7 +27,7 @@ let open_ inLang inText outLang outText => {
 
 let try_ text =>
   Protocol.Refmt.send
-    (normalizeText text)
+    text
     (
       fun response =>
         switch response {


### PR DESCRIPTION
A simple fix that will make it easier to refmt example code in the wild.